### PR TITLE
Use a better temperature of 0.7 instead of default 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ async function handleFetch(request) {
         prompt: finalPrompt	,
         max_tokens: 500,
         stop : ["###"],
+        temperature: 0.7,
     };
 
     // Make the first request to the Davinci model


### PR DESCRIPTION
When I was testing something like "there is only a blue car, black car, and a red car in the showroom" as context and later asked "do you have a green" car, the AI told me "yes of course we have a green car" (more or less), completely lying.
The OpenAI API actually default to temperature 1. The playground default to temperature 0.7.
With temperature 0.8 or above, the AI completely lied.
With 0.7, it answered "unfortunately we don't have green cars"... better.
Feel free to merge this or not. You can consider adding an option so you can send the temperature you want instead.
I just wanted to mention my experience playing with that stuff.